### PR TITLE
Fix how the request checksum is calculated and added to headers

### DIFF
--- a/api.lisp
+++ b/api.lisp
@@ -46,6 +46,7 @@
                      :method method
                      :headers `(("Authorization" . ,authorization)
                                 ("X-Amz-Date" . ,x-amz-date)
+				("x-amz-content-sha256" . ,(aws-sdk/utils::sha-256 (or payload "")))
                                 ,@(credential-headers credentials)
                                 ("Content-Type" . "application/x-amz-json-1.0")
                                 ,@headers)

--- a/utils.lisp
+++ b/utils.lisp
@@ -13,3 +13,8 @@
     (when (and (stringp value)
                (string/= value ""))
       value)))
+
+(defun sha-256 (str)
+  (ironclad:byte-array-to-hex-string
+   (ironclad:digest-sequence :sha256
+                             (ironclad:ascii-string-to-byte-array str))))


### PR DESCRIPTION
I've encountered some problems in how the library handled checksumming the requests. Here's a tiny fix.