### PR TITLE
Switch usages of `#p"~/..."` to use USER-HOMEDIR-PATHNAME

### DIFF
--- a/credentials/shared.lisp
+++ b/credentials/shared.lisp
@@ -15,7 +15,8 @@
 
 (defclass shared-provider (provider)
   ((file :initarg :file
-         :initform #P"~/.aws/credentials")
+         :initform (merge-pathnames ".aws/credentials"
+                                    (user-homedir-pathname)))
    (profile :initarg :profile
             :initform *aws-profile*
             :accessor provider-profile)

--- a/shared-config.lisp
+++ b/shared-config.lisp
@@ -34,7 +34,7 @@
 (defstruct (shared-config (:constructor %make-shared-config))
   (credentials-path (merge-pathnames ".aws/credentials"
                                      (user-homedir-pathname)))
-  (config-path (merge-pathnames ".aws/credentials"
+  (config-path (merge-pathnames ".aws/config"
                                 (user-homedir-pathname)))
   profile
 

--- a/shared-config.lisp
+++ b/shared-config.lisp
@@ -32,8 +32,10 @@
   credentials)
 
 (defstruct (shared-config (:constructor %make-shared-config))
-  (credentials-path #P"~/.aws/credentials")
-  (config-path #P"~/.aws/config")
+  (credentials-path (merge-pathnames ".aws/credentials"
+                                     (user-homedir-pathname)))
+  (config-path (merge-pathnames ".aws/credentials"
+                                (user-homedir-pathname)))
   profile
 
   region


### PR DESCRIPTION
On lispworks, at least, `#p` expands to an absolute path at
build/delivery time, which makes the result potentially invalid on the
end-user's machine.