### PR TITLE
An error will occur if the argument has a boolean type

### DIFF
--- a/api.lisp
+++ b/api.lisp
@@ -38,11 +38,11 @@
                                :method method
                                :host host
                                :path path
-                               :params (mapcar #'(lambda (x) (if (eq (cdr x) t) (cons (car x) "true") x)) params)
+                               :params params
                                :headers headers
                                :payload (or payload ""))
         (dex:request (format nil "https://~A~A?~A" host path
-                             (quri:url-encode-params (mapcar #'(lambda (x) (if (eq (cdr x) t) (cons (car x) "true") x)) params)))
+                             (quri:url-encode-params params))
                      :method method
                      :headers `(("Authorization" . ,authorization)
                                 ("X-Amz-Date" . ,x-amz-date)

--- a/api.lisp
+++ b/api.lisp
@@ -38,11 +38,11 @@
                                :method method
                                :host host
                                :path path
-                               :params params
+                               :params (mapcar #'(lambda (x) (if (eq (cdr x) t) (cons (car x) "true") x)) params)
                                :headers headers
                                :payload (or payload ""))
         (dex:request (format nil "https://~A~A?~A" host path
-                             (quri:url-encode-params params))
+                             (quri:url-encode-params (mapcar #'(lambda (x) (if (eq (cdr x) t) (cons (car x) "true") x)) params)))
                      :method method
                      :headers `(("Authorization" . ,authorization)
                                 ("X-Amz-Date" . ,x-amz-date)

--- a/generator/shape.lisp
+++ b/generator/shape.lisp
@@ -52,7 +52,7 @@
                collect (cons (format nil "~A.member.~A" key i) v))))
     (boolean
      (list (cons key
-		 (if (eq value t)
+		 (if value
 		     "true"
 		     "false"))))
     (otherwise (list (cons key value)))))

--- a/generator/shape.lisp
+++ b/generator/shape.lisp
@@ -50,6 +50,11 @@
          (loop for i from 1
                for v in value
                collect (cons (format nil "~A.member.~A" key i) v))))
+    (boolean
+     (list (cons key
+		 (if (eq value t)
+		     "true"
+		     "false"))))
     (otherwise (list (cons key value)))))
 
 (defun compile-structure-shape (name &key required members)


### PR DESCRIPTION
Thank you for the wonderful package.

For example, the following pattern will result in an error.

`(aws/ssm:get-parameters :names '("/hogehoge/path" "/hogehoge/path2") :with-decryption t)`

Bool value cannot be entered in quri.

` The value of QURI.ENCODE::VALUE is T, which is not of type (OR
                                                            STRING
                                                            NUMBER
                                                            QURI.UTIL:SIMPLE-BYTE-VECTOR).
`